### PR TITLE
feat: (SelectButton.js,Root2.js) - 자리 선택 및 확정 API 연동 테스트 코드

### DIFF
--- a/src/test/components/seats/Root2.js
+++ b/src/test/components/seats/Root2.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Col, Container, Row } from "react-bootstrap";
-import Select from "./Select";
+// import Select from "./Select";
 import SelectButton from "./SelectButton";
 
 export default function Root2() {
@@ -15,7 +15,7 @@ export default function Root2() {
         <Col xs={8} sm={6} className="d-flex justify-content-center">
           <div style={{ display: "flex" }}>
             <h3>실시간 자리 현황</h3>
-            <Select />
+            {/* <Select /> */}
             <SelectButton />
           </div>
         </Col>

--- a/src/test/components/seats/SelectButton.js
+++ b/src/test/components/seats/SelectButton.js
@@ -1,11 +1,43 @@
+import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
+import axios from "axios";
+import { useState } from "react";
 
-function SelectButton() {
+const SelectButton = () => {
+  const [selectedOption, setSelectedOption] = useState(0);
+
+  const fetchUserInfo = async () => {
+    try {
+      const id = 2; //테스트
+      const reason = "질문해야해서"; //테스트
+      const response = await axios.post("/seats/live", {
+        id,
+        seat_option: selectedOption,
+        reason,
+      });
+      console.log(response.data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   return (
-    <>
-      <Button variant="info">확인</Button>{" "}
-    </>
+    <div style={{ display: "flex" }}>
+      <Form.Select
+        aria-label="Default select example"
+        defaultValue={0}
+        style={{ width: "100px" }}
+        onChange={(e) => setSelectedOption(Number(e.target.value))}
+      >
+        <option value={0}>랜덤</option>
+        <option value={1}>앞자리</option>
+        <option value={-1}>뒷자리</option>
+      </Form.Select>
+      <Button variant="info" onClick={fetchUserInfo}>
+        확인
+      </Button>{" "}
+    </div>
   );
-}
+};
 
 export default SelectButton;


### PR DESCRIPTION
#27

## #️⃣ 요약
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

•	자리 선택 (맨앞, 맨뒤, 랜덤) 후 확인 버튼 클릭에 따른 db 변경 ( seat_option, reason )
1.	id가 2인 기존 db
 
![image](https://github.com/Pda4thMiniProject4th/shitdown-fe/assets/97513263/b6c6845b-434e-47ce-8559-609a40cc9bf5)

2.	뒷 자리 선택 후 확인 버튼
 
![image](https://github.com/Pda4thMiniProject4th/shitdown-fe/assets/97513263/00ad0f86-c517-4d62-945d-bef17c8d1228)

3.	id가 2인 변경 db
 
![image](https://github.com/Pda4thMiniProject4th/shitdown-fe/assets/97513263/bc0a3649-b4fb-4a4c-95f7-716dae0f94a6)


## ⚙️ 이슈 번호
- close

<br></br>
